### PR TITLE
Fixed 'Cannot read property '_s2mail' of undefined' on product create or edit page

### DIFF
--- a/classes/class-s2-block-editor.php
+++ b/classes/class-s2-block-editor.php
@@ -13,8 +13,8 @@ class S2_Block_Editor {
 		add_action( 'rest_api_init', array( $this, 'register_settings_endpoint' ) );
 
 		if ( is_admin() ) {
-			add_action( 'admin_enqueue_scripts', array( &$this, 'gutenberg_block_editor_assets' ), 6 );
-			add_action( 'admin_enqueue_scripts', array( &$this, 'gutenberg_i18n' ), 6 );
+			add_action( 'enqueue_block_editor_assets', array( &$this, 'gutenberg_block_editor_assets' ), 6 );
+			add_action( 'enqueue_block_editor_assets', array( &$this, 'gutenberg_i18n' ), 6 );
 		}
 	}
 
@@ -161,15 +161,6 @@ class S2_Block_Editor {
 	 * Enqueue Block Editor assets
 	 */
 	public function gutenberg_block_editor_assets() {
-		global $pagenow;
-		if ( ! in_array( $pagenow, array( 'post-new.php', 'post.php', 'page-new.php', 'page.php' ), true ) ) {
-			return;
-		}
-
-		if ( ! in_array( get_post_type(), array( 'post', 'page' ) ) ) {
-			return;
-		}
-
 		wp_enqueue_script(
 			'subscribe2-shortcode',
 			S2URL . 'gutenberg/shortcode' . $this->script_debug . '.js',
@@ -198,15 +189,6 @@ class S2_Block_Editor {
 	 * Handle translation of Block Editor assets
 	 */
 	public function gutenberg_i18n() {
-		global $pagenow;
-		if ( ! in_array( $pagenow, array( 'post-new.php', 'post.php', 'page-new.php', 'page.php' ), true ) ) {
-			return;
-		}
-		
-		if ( ! in_array( get_post_type(), array( 'post', 'page' ) ) ) {
-			return;
-		}
-
 		$translations = get_translations_for_domain( 'subscribe2' );
 
 		$locale_data = array(

--- a/classes/class-s2-block-editor.php
+++ b/classes/class-s2-block-editor.php
@@ -161,8 +161,7 @@ class S2_Block_Editor {
 	 * Enqueue Block Editor assets
 	 */
 	public function gutenberg_block_editor_assets() {
-		global $pagenow;
-		if ( ! in_array( $pagenow, array( 'post-new.php', 'post.php', 'page-new.php', 'page.php' ), true ) ) {
+		if ( ! in_array( get_post_type(), array( 'post', 'page' ) ) ) {
 			return;
 		}
 

--- a/classes/class-s2-block-editor.php
+++ b/classes/class-s2-block-editor.php
@@ -161,6 +161,11 @@ class S2_Block_Editor {
 	 * Enqueue Block Editor assets
 	 */
 	public function gutenberg_block_editor_assets() {
+		global $pagenow;
+		if ( ! in_array( $pagenow, array( 'post-new.php', 'post.php', 'page-new.php', 'page.php' ), true ) ) {
+			return;
+		}
+
 		if ( ! in_array( get_post_type(), array( 'post', 'page' ) ) ) {
 			return;
 		}
@@ -195,6 +200,10 @@ class S2_Block_Editor {
 	public function gutenberg_i18n() {
 		global $pagenow;
 		if ( ! in_array( $pagenow, array( 'post-new.php', 'post.php', 'page-new.php', 'page.php' ), true ) ) {
+			return;
+		}
+		
+		if ( ! in_array( get_post_type(), array( 'post', 'page' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
- Load Gutenberg block scripts using `enqueue_block_editor_assets` hook instead of `admin_enqueue_scripts` and check `$pagenow`. WooCommerce product is using same `post.php` and `post-new.php` file, So it cause an error on js script.

- This PR will fixed that support [issue](https://wordpress.org/support/topic/error-between-subscribe2-and-yoast-seo-when-editing-products-in-woocommerce/).