### PR TITLE
Only run 'SHOW TABLES' install check when an administrator is on the Dashboard

### DIFF
--- a/classes/class-s2-core.php
+++ b/classes/class-s2-core.php
@@ -1877,11 +1877,13 @@ class S2_Core {
 		}
 
 		// do we need to install anything?
-		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->subscribe2 ) ) !== $wpdb->subscribe2 ) {
-			require_once S2PATH . 'classes/class-s2-upgrade.php';
-			global $s2_upgrade;
-			$s2_upgrade = new S2_Upgrade();
-			$s2_upgrade->install();
+		if ( is_admin() && current_user_can( 'manage_options' ) ) {
+			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->subscribe2 ) ) !== $wpdb->subscribe2 ) {
+				require_once S2PATH . 'classes/class-s2-upgrade.php';
+				global $s2_upgrade;
+				$s2_upgrade = new S2_Upgrade();
+				$s2_upgrade->install();
+			}
 		}
 
 		//do we need to upgrade anything?


### PR DESCRIPTION
The `S2_Core::s2init()` method, which runs at `'plugins_loaded'` on every pageload, performs a `SHOW TABLES LIKE ...` query in order to see whether installation is required.

This frequent query is problematic. On installations with many database tables, such as a large Multisite installation, `SHOW TABLES LIKE ...` queries can take a long time to execute. For example, on the client site where I noticed this issue, with around 15,000 sites, `SHOW TABLES LIKE...` queries can take more than half a second to complete.

Moreover, this particular check is to see whether installation is necessary. In theory, installation should *never* be necessary, except the very first pageload after activation. So the query is unnecessary in the vast majority of cases.

There are a couple of ways to work around this:

* Depend on a `version` flag like you do for the upgrade routine.
* Run some other kind of query that isn't so costly. Ouch as `$wpdb->get_var( "SELECT id FROM wp_subscribe2 ORDER BY ID DESC LIMIT 1" )`, which would check for the first entry in the `wp_subscribe` table (perhaps you could have a placeholder entry so that it always returns an item if the table exists)
* Move the installation routine to an activation hook https://developer.wordpress.org/reference/functions/register_activation_hook/
* Limit the frequency with which the query is run.

The first three options seem like they're worth exploring. But I've opted to send a pull request that uses the last option, because it requires the least amount of code changes. I'm limiting the query to pageloads by someone with the `manage_options` capability, when viewing wp-admin. This doesn't solve the problem generally, but it does prevent the worst of the performance issues.