### PR TITLE
fix/subscribe2-settings-related-issues

### DIFF
--- a/admin/send-email.php
+++ b/admin/send-email.php
@@ -97,9 +97,12 @@ if ( 'mail' === $s2_admin ) {
 		}
 	} else {
 		global $phpmailer;
-		$message = '<p class="s2_error">' . __( 'Message failed!', 'subscribe2' ) . '</p>' . $error_message . $phpmailer->ErrorInfo;
+
+		$mailer_error = ! empty( $phpmailer->ErrorInfo ) ? $phpmailer->ErrorInfo : '';
+		$message      = '<p class="s2_error">' . __( 'Message failed!', 'subscribe2' ) . '</p>' . $error_message . $mailer_error;
 	}
-	echo '<div id="message" class="updated"><strong><p>' . wp_kses_post( $message ) . '</p></strong></div>' . "\r\n";
+
+	echo '<div id="message" class="' . ( $success ? 'updated' : 'error' ) . '"><strong><p>' . wp_kses_post( $message ) . '</p></strong></div>' . "\r\n";
 }
 
 // show our form
@@ -118,7 +121,7 @@ if ( isset( $_POST['subject'] ) ) {
 
 echo '<p>' . esc_html__( 'Subject', 'subscribe2' ) . ': <input type="text" size="69" name="subject" value="' . esc_attr( $subject ) . '" /> <br><br>';
 echo '<textarea rows="12" cols="75" name="content">' . $body . '</textarea>';
-echo "<br><div id=\"upload_files\"><input type=\"file\" name=\"file[]\"></div>\r\n";
+echo "<br><div id=\"upload_files\"><input type=\"file\" name=\"file[]\" onChange=\"remove_selected_image()\"></div>\r\n";
 echo '<input type="button" class="button-secondary" name="addmore" value="' . esc_attr( __( 'Add More Files', 'subscribe2' ) ) . "\" onClick=\"add_file_upload();\" />\r\n";
 echo "<br><br>\r\n";
 echo esc_html__( 'Recipients:', 'subscribe2' ) . ' ';
@@ -129,14 +132,56 @@ echo '</form></div>' . "\r\n";
 echo '<div style="clear: both;"><p>&nbsp;</p></div>';
 ?>
 <script type="text/javascript">
-//<![CDATA[
-function add_file_upload() {
-	var div = document.getElementById( 'upload_files' );
-	var field = div.getElementsByTagName( 'input' )[0];
-	div.appendChild( document.createElement( 'br' ) );
-	div.appendChild( field.cloneNode( false ) );
-}
-//]]>
+    //<![CDATA[
+    function add_file_upload() {
+        const fileUploadContainer = document.getElementById('upload_files'),
+            fileNode = document.createElement('input'),
+            spanNode = document.createElement('span'),
+            lineBreak = document.createElement('br');
+
+        // Insert multiple file.
+        if (!Boolean(fileNode.value)) {
+            fileNode.type = 'file';
+            fileNode.name = 'file[]';
+            spanNode.classList.add('dashicons', 'dashicons-no-alt');
+            spanNode.style.marginTop = '4px';
+
+            fileUploadContainer.appendChild(lineBreak);
+            fileUploadContainer.appendChild(fileNode);
+            fileUploadContainer.appendChild(spanNode);
+        }
+
+        // Remove uploaded image if selected otherwise remove field.
+        spanNode.addEventListener('click', function () {
+            if (Boolean(fileNode.value)) {
+                fileNode.value = '';
+                return;
+            }
+
+            fileNode.remove();
+            spanNode.remove();
+            lineBreak.remove();
+        });
+    }
+
+    // Handle first selected image.
+    function remove_selected_image() {
+        const fileUploadContainer = document.getElementById('upload_files'),
+            firstFile = fileUploadContainer.getElementsByTagName('input')[0],
+            spanNode = document.createElement('span');
+
+        if (!Boolean(firstFile.nextSibling)) {
+            spanNode.style.marginTop = '4px';
+            spanNode.classList.add('dashicons', 'dashicons-no-alt');
+            firstFile.after(spanNode);
+        }
+
+        spanNode.addEventListener('click', function () {
+            firstFile.value = '';
+            this.remove();
+        });
+    }
+    //]]>
 </script>
 <?php
 require ABSPATH . 'wp-admin/admin-footer.php';

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -61,7 +61,7 @@ if ( isset( $_POST['s2_admin'] ) ) {
 				}
 			} elseif ( in_array( $key, array( 'notification_subject', 'mailtext', 'confirm_subject', 'confirm_email', 'remind_subject', 'remind_email' ), true ) && ! empty( $_POST[ $key ] ) ) {
 				// Email subject and body templates.
-				$this->subscribe2_options[ $key ] = sanitize_text_field( trim( $_POST[ $key ] ) );
+				$this->subscribe2_options[ $key ] = in_array( $key, array( 'notification_subject', 'confirm_subject', 'remind_subject' ) ) ? sanitize_text_field( trim( $_POST[ $key ] ) ) : sanitize_textarea_field( trim( $_POST[ $key ] ) );
 			} elseif ( in_array( $key, array( 'compulsory', 'exclude', 'format' ), true ) ) {
 				sort( $_POST[ $key ] );
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,14 @@
+= 10.40 (24th January, 2023) =
+
+* Fix: {UNSUBLINK} tag not working properly when send an email.
+* Fix: subscribe2 emails no longer sending when publish a post.
+* Fix: template entities not working properly in settings page (line breaks, tabs were lost etc.).
+* Fix: subscribe2 notification overridden checkbox not working properly.
+* Fix: debug error when uninstall plugin & use error suppression.
+* Fix: email sending is always selected when multiple choose attachment.
+
+* Enhance: add email attachment removing option from send email.
+
 = 10.39 (23st December, 2022) =
 
  * Fix classic editor page meta field error.

--- a/classes/class-s2-admin.php
+++ b/classes/class-s2-admin.php
@@ -540,7 +540,7 @@ class S2_Admin extends S2_Core {
 			}
 		}
 
-		$subscribe_meta_field = ! empty( $_POST['s2_meta_field'] ) ? sanitize_text_field( $_POST['s2_meta_field'] ) : 'no';
+		$subscribe_meta_field = ! empty( $_POST['s2_meta_field'] ) ? sanitize_text_field( $_POST['s2_meta_field'] ) : 'yes';
 		if ( ! empty( $subscribe_meta_field ) && 'no' === $subscribe_meta_field ) {
 			update_post_meta( $post_id, '_s2mail', $subscribe_meta_field );
 		} else {

--- a/classes/class-s2-core.php
+++ b/classes/class-s2-core.php
@@ -157,9 +157,7 @@ class S2_Core {
 
 		if ( strstr( $string, '{TINYLINK}' ) ) {
 			$response = wp_safe_remote_get( 'http://tinyurl.com/api-create.php?url=' . rawurlencode( $this->get_tracking_link( $this->permalink ) ) );
-			if ( ! is_wp_error( $response ) ) {
-				$tinylink = wp_remote_retrieve_body( $response );
-			}
+			$tinylink = ! is_wp_error( $response ) ? wp_remote_retrieve_body( $response ) : '';
 
 			if ( false !== $tinylink ) {
 				$tlink  = '<a href="' . $tinylink . '">' . $tinylink . '</a>';
@@ -2204,7 +2202,7 @@ class S2_Core {
 		}
 
 		// Load our translations.
-		add_action( 'init', array( &$this, 'load_translations' ) );
+		add_action( 'init', array( $this, 'load_translations' ) );
 
 		// Define and register table name.
 		$s2_table = $wpdb->prefix . 'subscribe2';
@@ -2270,25 +2268,25 @@ class S2_Core {
 
 		// Add actions for comment subscribers.
 		if ( 'no' !== $this->subscribe2_options['comment_subs'] ) {
-			add_filter( 'jetpack_get_available_modules', array( &$this, 's2_hide_jetpack_comments' ) );
-			add_filter( 'comment_form_submit_field', array( &$this, 's2_comment_meta_form' ) );
-			add_action( 'comment_post', array( &$this, 's2_comment_meta' ), 1, 2 );
-			add_action( 'wp_set_comment_status', array( &$this, 'comment_status' ) );
+			add_filter( 'jetpack_get_available_modules', array( $this, 's2_hide_jetpack_comments' ) );
+			add_filter( 'comment_form_submit_field', array( $this, 's2_comment_meta_form' ) );
+			add_action( 'comment_post', array( $this, 's2_comment_meta' ), 1, 2 );
+			add_action( 'wp_set_comment_status', array( $this, 'comment_status' ) );
 		}
 
 		// Add action to display widget if option is enabled.
 		if ( '1' === $this->subscribe2_options['widget'] ) {
-			add_action( 'widgets_init', array( &$this, 'subscribe2_widget' ) );
+			add_action( 'widgets_init', array( $this, 'subscribe2_widget' ) );
 		}
 
 		// Add action to display counter widget if option is enabled.
 		if ( '1' === $this->subscribe2_options['counterwidget'] ) {
-			add_action( 'widgets_init', array( &$this, 'counter_widget' ) );
+			add_action( 'widgets_init', array( $this, 'counter_widget' ) );
 		}
 
 		// Add action to 'clean' unconfirmed Public Subscribers.
 		if ( is_int( $this->clean_interval ) && $this->clean_interval > 0 ) {
-			add_action( 'wp_scheduled_delete', array( &$this, 's2cleaner_task' ) );
+			add_action( 'wp_scheduled_delete', array( $this, 's2cleaner_task' ) );
 		}
 
 		// Add ajax class if enabled.

--- a/classes/class-s2-frontend.php
+++ b/classes/class-s2-frontend.php
@@ -13,7 +13,6 @@ class S2_Frontend extends S2_Core {
 	public function unsubscribe( $email ) {
 	    global $wpdb;
 
-        $email = base64_decode( $email );
         if ( ! filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
             return;
         }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://getwemail.io
 Tags: posts, subscription, email, subscribe, notify, notification, newsletter, post notification, email marketing, optin, form
 Requires at least: 4.0
 Tested up to: 6.1.1
-Stable tag: 10.39
+Stable tag: 10.40
 Requires PHP: 5.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -71,6 +71,17 @@ This token will automatically be replaced by dynamic subscription information an
 [Visit FAQ site](https://subscribe2.wordpress.com/support/faqs/)
 
 == Changelog ==
+
+= 10.40 (24th January, 2023) =
+
+* Fix: {UNSUBLINK} tag not working properly when send an email.
+* Fix: subscribe2 emails no longer sending when publish a post.
+* Fix: template entities not working properly in settings page (line breaks, tabs were lost etc.).
+* Fix: subscribe2 notification overridden checkbox not working properly.
+* Fix: debug error when uninstall plugin & use error suppression.
+* Fix: email sending is always selected when multiple choose attachment.
+
+* Enhance: add email attachment removing option from send email.
 
 = 10.39 (23st December, 2022) =
 

--- a/subscribe2.php
+++ b/subscribe2.php
@@ -3,7 +3,7 @@
 Plugin Name: Subscribe2
 Plugin URI: https://getwemail.io
 Description: Notifies an email list when new entries are posted.
-Version: 10.39
+Version: 10.40
 Author: weMail
 Author URI: https://getwemail.io
 Licence: GPLv3
@@ -55,7 +55,7 @@ if ( is_plugin_active_for_network( plugin_basename( __FILE__ ) ) ) {
 
 // Our version number. Don't touch this or any line below.
 // Unless you know exactly what you are doing.
-define( 'S2VERSION', '10.39' );
+define( 'S2VERSION', '10.40' );
 define( 'S2PLUGIN', __FILE__ );
 define( 'S2PATH', trailingslashit( dirname( __FILE__ ) ) );
 define( 'S2DIR', trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );

--- a/traits/ShortcodeTrait.php
+++ b/traits/ShortcodeTrait.php
@@ -59,7 +59,7 @@ trait Shortcode {
         $this->unsubscribe = __( 'unsubscribe', 'subscribe2' ); //ACTION replacement in unsubscribing in confirmation email
 
         if ( ! empty( $_GET['s2_unsub'] ) ) {
-            $this->unsubscribe( sanitize_email( $_GET['s2_unsub'] ) );
+	        $this->unsubscribe( sanitize_email( base64_decode( $_GET['s2_unsub'] ) ) );
         }
     }
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,8 +8,10 @@ if ( is_plugin_active( 'subscribe2_html/subscribe2.php' ) ) {
 	return;
 }
 
+$s2_mu = false;
+
 // Is this WordPressMU or not?
-if ( isset( $wpmu_version ) || strpos( $wp_version, 'wordpress-mu' ) ) {
+if ( isset( $wpmu_version ) || ( isset( $wp_version ) && strpos( $wp_version, 'wordpress-mu' ) ) ) {
 	$s2_mu = true;
 }
 


### PR DESCRIPTION
### Fixes all subscribe2 settings related issues.

- [x] [Fix for not working {UNSUBLINK}](https://wordpress.org/support/topic/fix-for-not-working-unsublink/)
- [x] [S2 Emails no longer sending](https://wordpress.org/support/topic/s2-emails-no-longer-sending/)
- [x] [fix for templates in settings page (line breaks, tabs were lost)](https://wordpress.org/support/topic/fix-for-templates-in-settings-page-line-breaks-tabs-were-lost/)
- [x] [Fix for not sending mails](https://wordpress.org/support/topic/fix-for-not-sending-mails/)
- [x] [Email sending is being always selected when multiple attachment choosen](https://github.com/weMail/Subscribe2/issues/17)
- [x] [Fix error suppression error](https://github.com/weMail/Subscribe2/issues/17)
- [x] [Added image fields removing option](https://github.com/weMail/Subscribe2/issues/16)

Relevant Issue: [Link](https://github.com/weMail/Subscribe2/issues/16)
Relevant Issue: [Link](https://github.com/weMail/Subscribe2/issues/17)