### PR TITLE
fix: add sanitization when storing subscribers

### DIFF
--- a/classes/class-s2-admin.php
+++ b/classes/class-s2-admin.php
@@ -1,5 +1,8 @@
 <?php
 class S2_Admin extends S2_Core {
+	public $signup_dates;
+	public $signup_times;
+	public $signup_ips;
 
 	/**
 	 * Register wp menu & handle scripts.

--- a/classes/class-s2-block-editor.php
+++ b/classes/class-s2-block-editor.php
@@ -4,6 +4,7 @@
  * Block editor handler class.
  */
 class S2_Block_Editor {
+	public $script_debug;
 
 	/**
 	 * Constructor

--- a/classes/class-s2-core.php
+++ b/classes/class-s2-core.php
@@ -112,6 +112,13 @@ class S2_Core {
 	 * @var array|null
 	 */
 	public $post_tag_names;
+	public $script_debug;
+	public $word_wrap;
+	public $excerpt_length;
+	public $site_switching;
+	public $clean_interval;
+	public $lockout;
+	public $wp_release;
 
 	/**
 	 * Load plugin translations.
@@ -974,9 +981,11 @@ class S2_Core {
 		} else {
 			if ( $confirm ) {
 				global $current_user;
-				$wpdb->query( $wpdb->prepare( "INSERT INTO $wpdb->subscribe2 (email, active, date, time, ip) VALUES (%s, %d, CURDATE(), CURTIME(), %s)", $email, 1, $current_user->user_login ) );
+				$wpdb->query( $wpdb->prepare( "INSERT INTO $wpdb->subscribe2 (email, active, date, time, ip) VALUES (%s, %d, CURDATE(), CURTIME(), %s)",
+					sanitize_email( $email ), 1, sanitize_textarea_field( $current_user->user_login ) )
+				);
 			} else {
-				$wpdb->query( $wpdb->prepare( "INSERT INTO $wpdb->subscribe2 (email, active, date, time, ip) VALUES (%s, %d, CURDATE(), CURTIME(), %s)", $email, 0, $this->ip ) );
+				$wpdb->query( $wpdb->prepare( "INSERT INTO $wpdb->subscribe2 (email, active, date, time, ip) VALUES (%s, %d, CURDATE(), CURTIME(), %s)", sanitize_email( $email ), 0, sanitize_text_field( $this->ip ) ) );
 			}
 		}
 	}

--- a/include/appsero/src/Client.php
+++ b/include/appsero/src/Client.php
@@ -191,7 +191,7 @@ class Client {
 
             require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-            $plugin_data = get_plugin_data( $this->file );
+            $plugin_data = get_plugin_data( $this->file, true, false );
 
             $this->project_version = $plugin_data['Version'];
             $this->type            = 'plugin';

--- a/traits/ShortcodeTrait.php
+++ b/traits/ShortcodeTrait.php
@@ -4,6 +4,24 @@
  * Shortcode handler class.
  */
 trait Shortcode {
+	public $please_log_in;
+	public $confirmation_sent;
+	public $already_subscribed;
+	public $not_subscribed;
+	public $not_an_email;
+	public $barred_domain;
+	public $error;
+	public $no_such_email;
+	public $added;
+	public $deleted;
+	public $subscribe;
+	public $unsubscribe;
+	public $input_form_action;
+	public $form;
+	public $s2form;
+	public $email;
+	public $ip;
+	public $action;
 
 	/**
 	 * @var ?string


### PR DESCRIPTION
1. add sanitization when storing subscribers
2. WordPress `load_plugin_textdomain` warning handled
3. PHP creation of dynamic property warning handled for multiple files