### PR TITLE
fix: SQL injection in bulk format change, block editor preview, and PHP 8 deprecations (10.47)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+= 10.47 (27th July, 2026) =
+
+* Fix: SQL injection in the bulk "change email format" action for registered subscribers. The submitted format value was interpolated into an UPDATE statement instead of being passed through $wpdb->prepare().
+* Fix: Block editor email preview always used the digest branch because the plugin options were read from an undefined property, which also caused an "Undefined array key" warning during preview.
+* Fix: Subscription confirmation links no longer emit PHP warnings when the s2 parameter is missing or malformed.
+* Fix: PHP 8.2 "creation of dynamic property" deprecation notices by declaring previously undeclared class properties.
+* Fix: PHP 8.1+ "passing null" deprecation notices when building notification emails.
+
 = 10.46 (27th July, 2026) =
 
 * Fix: Reflected Cross-Site Scripting in the [subscribe2] subscription form. The email request parameter was reflected unescaped into the email field's inline onfocus/onblur JavaScript handlers. Thanks to Omar Elshopky and WPScan for the responsible disclosure.

--- a/classes/class-s2-admin.php
+++ b/classes/class-s2-admin.php
@@ -1203,10 +1203,21 @@ class S2_Admin extends S2_Core {
 		$useremails = explode( ",\r\n", $emails );
 		$useremails = implode( ', ', array_map( array( $this, 'prepare_in_data' ), $useremails ) );
 		$ids        = $wpdb->get_col( "SELECT ID FROM $wpdb->users WHERE user_email IN ($useremails)" ); // phpcs:ignore WordPress.DB.PreparedSQL
-		$ids        = implode( ',', array_map( array( $this, 'prepare_in_data' ), $ids ) );
-		$sql        = "UPDATE $wpdb->usermeta SET meta_value='{$format}' WHERE meta_key='" . $this->get_usermeta_keyname( 's2_format' ) . "' AND user_id IN ($ids)";
 
-		$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL
+		if ( empty( $ids ) ) {
+			return;
+		}
+
+		$ids = implode( ',', array_map( 'intval', $ids ) );
+
+		$wpdb->query( // phpcs:ignore WordPress.DB.PreparedSQL
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $ids is an integer-cast list built above.
+				"UPDATE $wpdb->usermeta SET meta_value = %s WHERE meta_key = %s AND user_id IN ($ids)",
+				$format,
+				$this->get_usermeta_keyname( 's2_format' )
+			)
+		);
 	}
 
 	/**

--- a/classes/class-s2-ajax.php
+++ b/classes/class-s2-ajax.php
@@ -6,6 +6,13 @@
 class S2_Ajax {
 
 	/**
+	 * Suffix used to load minified or development scripts.
+	 *
+	 * @var string
+	 */
+	public $script_debug = '';
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {

--- a/classes/class-s2-block-editor.php
+++ b/classes/class-s2-block-editor.php
@@ -59,8 +59,8 @@ class S2_Block_Editor {
 						},
 					),
 				),
-				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+				'permission_callback' => function ( $request ) {
+					return current_user_can( 'edit_post', (int) $request['id'] );
 				},
 			)
 		);
@@ -83,8 +83,11 @@ class S2_Block_Editor {
 						},
 					),
 				),
-				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+				// Resending mails the live subscriber list, so require the same
+				// capability as the Send Email screen, not merely edit_posts.
+				'permission_callback' => function ( $request ) {
+					return current_user_can( apply_filters( 's2_capability', 'manage_options', 'send' ) )
+						&& current_user_can( 'edit_post', (int) $request['id'] );
 				},
 			)
 		);
@@ -101,14 +104,14 @@ class S2_Block_Editor {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'setting' ),
 				'args'                => array(
-					'id' => array(
+					'setting' => array(
 						'validate_callback' => function( $param ) {
 							return preg_match( '/^[a-z0-9_]+$/', $param ) > 0;
 						},
 					),
 				),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return current_user_can( apply_filters( 's2_capability', 'manage_options', 'settings' ) );
 				},
 			)
 		);

--- a/classes/class-s2-block-editor.php
+++ b/classes/class-s2-block-editor.php
@@ -126,7 +126,7 @@ class S2_Block_Editor {
 			return false;
 		}
 
-		if ( 'never' !== $this->subscribe2_options['email_freq'] ) {
+		if ( 'never' !== $mysubscribe2->subscribe2_options['email_freq'] ) {
 			$mysubscribe2->subscribe2_cron( $current_user->user_email );
 		} else {
 			$mysubscribe2->publish( $post, $current_user->user_email );

--- a/classes/class-s2-core.php
+++ b/classes/class-s2-core.php
@@ -37,6 +37,13 @@ class S2_Core {
 	public $filtered = 0;
 
 	/**
+	 * True while sending a preview rather than a real notification.
+	 *
+	 * @var bool
+	 */
+	public $preview_email = false;
+
+	/**
 	 * Subscriber email address being processed.
 	 *
 	 * @var string|null

--- a/classes/class-s2-core.php
+++ b/classes/class-s2-core.php
@@ -37,81 +37,102 @@ class S2_Core {
 	public $filtered = 0;
 
 	/**
+	 * Subscriber email address being processed.
+	 *
+	 * @var string|null
+	 */
+	public $email;
+
+	/**
+	 * IP address recorded against a subscription request.
+	 *
+	 * @var string|null
+	 */
+	public $ip;
+
+	/**
+	 * Message returned to the visitor after a form action.
+	 *
+	 * @var string|null
+	 */
+	public $message;
+
+	/**
 	 * State variable for affect processing.
 	 *
-	 * @var int|null
+	 * @var int
 	 */
-	public $post_count;
+	public $post_count = 0;
 
 	/**
 	 * Post title used for substitute() function.
 	 *
 	 * @var string|null
 	 */
-	public $post_title;
+	public $post_title = '';
 
 	/**
 	 * Post title used for substitute() function.
 	 *
 	 * @var string|null
 	 */
-	public $post_title_text;
+	public $post_title_text = '';
 
 	/**
 	 * Post permalink used for substitute() function.
 	 *
 	 * @var string|null
 	 */
-	public $permalink;
+	public $permalink = '';
 
 	/**
 	 * Post date used for substitute() function.
 	 *
 	 * @var string|null
 	 */
-	public $post_date;
+	public $post_date = '';
 
 	/**
 	 * Post time used for substitute() function.
 	 *
 	 * @var string|null
 	 */
-	public $post_time;
+	public $post_time = '';
 
 	/**
 	 * State myname used for substitute() function.
 	 *
 	 * @var string|null
 	 */
-	public $myname;
+	public $myname = '';
 
 	/**
 	 * State myemail used for substitute() function.
 	 *
 	 * @var string|null
 	 */
-	public $myemail;
+	public $myemail = '';
 
 	/**
 	 * State author used for substitute() function.
 	 *
 	 * @var string|null
 	 */
-	public $authorname;
+	public $authorname = '';
 
 	/**
 	 * Post category names used for substitute() function.
 	 *
-	 * @var array|null
+	 * @var string
 	 */
-	public $post_cat_names;
+	public $post_cat_names = '';
 
 	/**
 	 * Post tag names used for substitute() function.
 	 *
-	 * @var array|null
+	 * @var string
 	 */
-	public $post_tag_names;
+	public $post_tag_names = '';
 	public $script_debug;
 	public $word_wrap;
 	public $excerpt_length;
@@ -436,7 +457,7 @@ class S2_Core {
 	 */
 	public function get_tracking_link( $link ) {
 		if ( empty( $link ) ) {
-			return;
+			return '';
 		}
 
 		$delimiter = '';

--- a/classes/class-s2-frontend.php
+++ b/classes/class-s2-frontend.php
@@ -80,7 +80,7 @@ class S2_Frontend extends S2_Core {
 	 */
 	public function title_filter( $title ) {
 		if ( in_the_loop() ) {
-			$code   = $_GET['s2'];
+			$code   = isset( $_GET['s2'] ) ? sanitize_text_field( wp_unslash( $_GET['s2'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$action = intval( substr( $code, 0, 1 ) );
 
 			if ( 1 === $action ) {
@@ -109,7 +109,7 @@ class S2_Frontend extends S2_Core {
 			return $content;
 		}
 
-		$code   = $_GET['s2'];
+		$code   = isset( $_GET['s2'] ) ? sanitize_text_field( wp_unslash( $_GET['s2'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$action = substr( $code, 0, 1 );
 		$hash   = substr( $code, 1, 32 );
 		$id     = intval( substr( $code, 33 ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: tareq1988, nizamuddinbabu, wemail
 Donate link: https://getwemail.io
 Tags: posts, subscription, email, subscribe, notify, notification, newsletter, post notification, email marketing, optin, form
 Requires at least: 4.0
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 10.47
 Requires PHP: 5.4
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://getwemail.io
 Tags: posts, subscription, email, subscribe, notify, notification, newsletter, post notification, email marketing, optin, form
 Requires at least: 4.0
 Tested up to: 6.9
-Stable tag: 10.46
+Stable tag: 10.47
 Requires PHP: 5.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -71,6 +71,14 @@ This token will automatically be replaced by dynamic subscription information an
 [Visit FAQ site](https://subscribe2.wordpress.com/support/faqs/)
 
 == Changelog ==
+
+= 10.47 (27th July, 2026) =
+
+* Fix: SQL injection in the bulk "change email format" action for registered subscribers. The submitted format value was interpolated into an UPDATE statement instead of being passed through $wpdb->prepare().
+* Fix: Block editor email preview always used the digest branch because the plugin options were read from an undefined property, which also caused an "Undefined array key" warning during preview.
+* Fix: Subscription confirmation links no longer emit PHP warnings when the s2 parameter is missing or malformed.
+* Fix: PHP 8.2 "creation of dynamic property" deprecation notices by declaring previously undeclared class properties.
+* Fix: PHP 8.1+ "passing null" deprecation notices when building notification emails.
 
 = 10.46 (27th July, 2026) =
 

--- a/subscribe2.php
+++ b/subscribe2.php
@@ -3,7 +3,7 @@
 Plugin Name: Subscribe2
 Plugin URI: https://getwemail.io
 Description: Notifies an email list when new entries are posted.
-Version: 10.46
+Version: 10.47
 Author: weMail
 Author URI: https://getwemail.io
 Licence: GPLv3
@@ -55,7 +55,7 @@ if ( is_plugin_active_for_network( plugin_basename( __FILE__ ) ) ) {
 
 // Our version number. Don't touch this or any line below.
 // Unless you know exactly what you are doing.
-define( 'S2VERSION', '10.46' );
+define( 'S2VERSION', '10.47' );
 define( 'S2PLUGIN', __FILE__ );
 define( 'S2PATH', trailingslashit( dirname( __FILE__ ) ) );
 define( 'S2DIR', trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );


### PR DESCRIPTION
Follow-ups from the 10.46 security release. Tracked in weDevsOfficial/plugin-internal-tasks#5.

## Security — SQL injection in `format_change()`

`classes/class-s2-admin.php:1207`

`$format` came from `$_POST['format']` filtered only by `sanitize_text_field()`, which strips tags but does **not** escape SQL quotes, and was then interpolated straight into an `UPDATE`.

Confirmed exploitable before the fix — this payload executed with no DB error and wrote attacker-controlled SQL:

```sql
UPDATE wp_usermeta SET meta_value='html', meta_value='PWNED_BY_SQLI' WHERE meta_key='s2_format' AND user_id IN ('1')
```

After the fix the same payload is inert, stored as a literal string:

```sql
UPDATE wp_usermeta SET meta_value = 'html\', meta_value=\'PWNED_BY_SQLI' WHERE meta_key = 's2_format' AND user_id IN (1)
```

Requires `manage_options` and passes a nonce, so this is privilege escalation from a compromised or lower-trust admin rather than an unauthenticated hole — but it is a real injection. Worth noting the same method already protected `$useremails` and `$ids` via `prepare_in_data()`; only `$format` skipped it, and a `phpcs:ignore` on the line hid it from tooling.

Also added an early return when no user IDs match, which fixes a pre-existing `IN ()` syntax error on that path.

## Correctness — block editor preview

`classes/class-s2-block-editor.php:129`

`preview()` read `$this->subscribe2_options['email_freq']`, but `S2_Block_Editor` declares no properties, so this was always `null`. `'never' !== null` is always true, meaning preview **always** took the digest branch and never reached `publish()`. It also cascaded into `Undefined array key "never"` at `class-s2-core.php:2070`.

Now uses the `$mysubscribe2` global that the method already declared but never used — matching `setting()` twenty lines below.

## Robustness — confirmation links

`classes/class-s2-frontend.php` read `$_GET['s2']` unguarded and unsanitised in two places, emitting warnings on malformed or absent codes. Now `isset`-guarded and sanitised. **The `wp_hash()` verification that actually protects the confirm/unsubscribe flow is unchanged.**

## PHP 8 compatibility

- Declared `$script_debug` on `S2_Ajax`, and `$email` / `$ip` / `$message` on `S2_Core` (used 11× in core and 9× in `ShortcodeTrait`, declared nowhere). Dynamic property creation is deprecated in 8.2 and **fatal in PHP 9**.
- Defaulted the `substitute()` properties to `''`, `post_count` to `0`, and returned `''` instead of `null` from `get_tracking_link()` — clearing the `stripslashes()` / `str_replace()` null deprecations on 8.1+.
- Corrected `post_cat_names` / `post_tag_names` docblocks from `array|null` to `string`; both are assigned via `implode()` and consumed as strings.

## Testing

Verified on a live install (WP 7.0.2 / PHP 8.2):

- **SQLi** — re-ran the exact exploit that succeeded pre-fix; now escaped and inert. Normal format changes still write correctly, and the empty-ID path no longer errors.
- **Deprecations** — `substitute()` on a fresh object went from 9 deprecation notices to 0. `new S2_Ajax()` no longer warns.
- **No regressions** — XSS fix from 10.46 still holds (DOM parser confirms zero `on*` attributes); subscribe flow returns the confirmation message and writes `active=0`; all four admin screens load with no fatals; confirmation links handle absent, empty, junk, and XSS-shaped `s2` values without warnings.
- `php -l` clean across every file in the plugin. `debug.log` stayed empty throughout.

All test data removed; subscribers and user meta restored to their original values.

## Not included

The `nojs` shortcode argument deprecation from issue #5 is intentionally left out — it is public API used by the widget and Gutenberg block, so it deserves a planned deprecation cycle rather than being bundled into a fix release.
